### PR TITLE
chore: add issuer name to context

### DIFF
--- a/src/com/openattestation/1.0/OpenAttestation.v3.json
+++ b/src/com/openattestation/1.0/OpenAttestation.v3.json
@@ -41,10 +41,10 @@
             "mimeType": "xsd:string"
           }
         },
-        "issuer": {
-          "@id": "https://schemata.openattestation.com/vocab/#issuer",
+        "OpenAttestationIssuer": {
+          "@id": "https://schemata.openattestation.com/vocab/#OpenAttestationIssuer",
           "@context": {
-            "name": "xsd:string"
+            "name": "https://schemata.openattestation.com/vocab/#issuerName"
           }
         },
         "reference": "xsd:string",


### PR DESCRIPTION
Discussion started here: https://github.com/Open-Attestation/open-attestation/discussions/186


this is workaround for https://github.com/w3c/json-ld-syntax/issues/361

I am unsure if it is a good idea to put this in the context. As a VC creator, I would prefer to customize the full url for `issuer.name` field in my own custom context so that I can give it more specific semantics, like restricting allowed characters, or omit it completely, only requiring an "id".

