### PR TITLE
fix: decrease minItems of fhirBundle.entry

### DIFF
--- a/src/sg/gov/moh/pdt-healthcert/1.0/schema.json
+++ b/src/sg/gov/moh/pdt-healthcert/1.0/schema.json
@@ -445,7 +445,7 @@
         "entry": {
           "description": "An entry in a bundle resource - will contain information about Patient, Speciment, Observation or Organization.",
           "type": "array",
-          "minItems": 5,
+          "minItems": 4,
           "items": {
             "oneOf": [
               {

--- a/src/sg/gov/moh/pdt-healthcert/1.0/schema.test.ts
+++ b/src/sg/gov/moh/pdt-healthcert/1.0/schema.test.ts
@@ -271,9 +271,9 @@ describe("schema", () => {
           Object {
             "dataPath": ".fhirBundle.entry",
             "keyword": "minItems",
-            "message": "should NOT have fewer than 5 items",
+            "message": "should NOT have fewer than 4 items",
             "params": Object {
-              "limit": 5,
+              "limit": 4,
             },
             "schemaPath": "#/properties/fhirBundle/properties/entry/minItems",
           },


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/178653362

**Context**
PDT HealthCerts originally required 5 entries in `fhirBundle.entry`:
1. Patient
2. Specimen
3. Observation
4. Organization (Licensed Healthcare Provider)
5. Organization (Accredited Laboratory)

**Today**
With the introduction of Antigen Rapid Test (ART) HealthCerts, there is no longer a hard requirement for `Organization (Accredited Laboratory)` field.

As such, this PR aims to decrease the `minItems` of `fhirBundle.entry` from 5 to 4.