### PR TITLE
feat: add art examples in schema

### DIFF
--- a/src/sg/gov/moh/pdt-healthcert/1.0/schema.json
+++ b/src/sg/gov/moh/pdt-healthcert/1.0/schema.json
@@ -188,15 +188,7 @@
     "Observation": {
       "description": "Measurements and simple assertions made about a patient, device or other subject.",
       "type": "object",
-      "required": [
-        "resourceType",
-        "identifier",
-        "code",
-        "valueCodeableConcept",
-        "effectiveDateTime",
-        "qualification",
-        "status"
-      ],
+      "required": ["resourceType", "code", "valueCodeableConcept", "effectiveDateTime", "qualification", "status"],
       "properties": {
         "fullUrl": {
           "type": "string",

--- a/src/sg/gov/moh/pdt-healthcert/1.0/schema.json
+++ b/src/sg/gov/moh/pdt-healthcert/1.0/schema.json
@@ -167,7 +167,27 @@
         },
         "type": {
           "description": "The kind of material that forms the specimen.",
-          "$ref": "#/definitions/CodeableConcept"
+          "$ref": "#/definitions/CodeableConcept",
+          "examples": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "258500001",
+                  "display": "Nasopharyngeal swab"
+                }
+              ]
+            },
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "697989009",
+                  "display": "Anterior nares swab"
+                }
+              ]
+            }
+          ]
         },
         "collection": {
           "description": "Details concerning the specimen collection.",
@@ -221,7 +241,27 @@
         },
         "code": {
           "description": "Describes what was observed. Sometimes this is called the observation \"name\".",
-          "$ref": "#/definitions/CodeableConcept"
+          "$ref": "#/definitions/CodeableConcept",
+          "examples": [
+            {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "94531-1",
+                  "display": "Reverse transcription polymerase chain reaction (rRT-PCR) test"
+                }
+              ]
+            },
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "97097-0",
+                  "display": "SARS-CoV-2 (COVID-19) Ag [Presence] in Upper respiratory specimen by Rapid immunoassay"
+                }
+              ]
+            }
+          ]
         },
         "valueCodeableConcept": {
           "description": "The information determined as a result of making the observation, if the information has a simple value.",

--- a/src/sg/gov/moh/pdt-healthcert/1.0/schema.test.ts
+++ b/src/sg/gov/moh/pdt-healthcert/1.0/schema.test.ts
@@ -652,19 +652,6 @@ describe("schema", () => {
     });
 
     describe("Observation", () => {
-      it("should fail when identifier is missing", () => {
-        const document = omit(cloneDeep(sampleDocument), "fhirBundle.entry[2].identifier");
-        expect(validator(document)).toBe(false);
-        expect(validator.errors).toContainEqual({
-          dataPath: ".fhirBundle.entry[2]",
-          keyword: "required",
-          message: "should have required property 'identifier'",
-          params: {
-            missingProperty: "identifier"
-          },
-          schemaPath: "#/required"
-        });
-      });
       it("should fail when identifier is empty", () => {
         const document = set(cloneDeep(sampleDocument), "fhirBundle.entry[2].identifier", []);
         expect(validator(document)).toBe(false);


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/178738926

Instead of publishing separate document samples for both PCR and ART, this PR provides the examples directly in the schema itself. Especially since both PCR and ART are considered PDT HealthCerts.

**Changes**
1. Remove `Observation.identifier` from required field (instead of using "Not applicable")
2. Add PCR and ART examples for `Specimen.type`
3. Add PCR and ART examples for `Observation.code`