### PR TITLE
WIP: PDT HealthCert Schema v2.0

### DIFF
--- a/src/sg/gov/moh/pdt-healthcert/2.0/pdt-art-sample.json
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/pdt-art-sample.json
@@ -1,0 +1,281 @@
+{
+  "id": "30b51e5c-0330-4072-bdd8-d1fbdafa11ac",
+  "version": "PDT-HealthCert-v2.0",
+  "type": "ART",
+  "validFrom": "2021-05-18T06:43:12.152Z",
+  "fhirVersion": "4.0.1",
+  "fhirBundle": {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+        "resource": {
+          "resourceType": "Patient",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "extension": [
+                {
+                  "url": "code",
+                  "valueCodeableConcept": {
+                    "text": "Patient Nationality",
+                    "coding": [
+                      {
+                        "system": "urn:iso:std:iso:3166",
+                        "code": "SG"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "id": "PPN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "PPN",
+                    "display": "Passport Number"
+                  }
+                ]
+              },
+              "value": "E7831177G"
+            },
+            {
+              "id": "NRIC",
+              "value": "S9098989Z"
+            }
+          ],
+          "name": [
+            {
+              "text": "Tan Chen Chen"
+            }
+          ],
+          "gender": "female",
+          "birthDate": "1990-01-15"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+        "resource": {
+          "resourceType": "Specimen",
+          "subject": {
+            "type": "Device",
+            "reference": "urn:uuid:9103a5c8-5957-40f5-85a1-e6633e890777"
+          },
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "258500001",
+                "display": "Nasopharyngeal swab"
+              }
+            ]
+          },
+          "collection": {
+            "collectedDateTime": "2020-09-27T06:15:00Z"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+        "resource": {
+          "resourceType": "Observation",
+          "performer": [
+            {
+              "type": "Practitioner",
+              "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            }
+          ],
+          "identifier": [
+            {
+              "id": "ACSN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "ACSN",
+                    "display": "Accession ID"
+                  }
+                ]
+              },
+              "value": "123456789"
+            }
+          ],
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "840539006",
+                  "display": "COVID-19"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "94531-1",
+                "display": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
+              }
+            ]
+          },
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative"
+              }
+            ]
+          },
+          "effectiveDateTime": "2020-09-28T06:15:00Z",
+          "status": "final"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+        "resource": {
+          "resourceType": "Practitioner",
+          "name": [{ "text": "Dr Michael Lim" }],
+          "qualification": [
+            {
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MCR",
+                    "display": "Practitioner Medicare number"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "id": "MCR",
+                  "value": "123456"
+                }
+              ],
+              "issuer": {
+                "type": "Organization",
+                "reference": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "Ministry of Health (MOH)",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "govt",
+                  "display": "Government"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.moh.gov.sg" },
+                { "system": "phone", "value": "+6563259220" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Medical Clinic",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Licensed Healthcare Provider"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.macritchieclinic.com.sg" },
+                { "system": "phone", "value": "+6561234567" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "MacRitchie Hospital, Thomson Road, Singapore 123000"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:839a7c54-6b40-41cb-b10d-9295d7e75f77",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Laboratory",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Accredited Laboratory"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [{ "system": "phone", "value": "+6567654321" }],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "2 Thomson Avenue 4, Singapore 098888"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:9103a5c8-5957-40f5-85a1-e6633e890777",
+        "resource": {
+          "resourceType": "Device",
+          "type": {
+            "coding": [
+              {
+                "system": "https://covid-19-diagnostics.jrc.ec.europa.eu/devices",
+                "code": "1232",
+                "display": "Abbott Rapid Diagnostics, Panbio COVID-19 Ag Rapid Test"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/sg/gov/moh/pdt-healthcert/2.0/pdt-pcr-sample.json
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/pdt-pcr-sample.json
@@ -1,0 +1,262 @@
+{
+  "id": "30b51e5c-0330-4072-bdd8-d1fbdafa11ac",
+  "version": "PDT-HealthCert-v2.0",
+  "type": "PCR",
+  "validFrom": "2021-05-18T06:43:12.152Z",
+  "fhirVersion": "4.0.1",
+  "fhirBundle": {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:ba7b7c8d-c509-4d9d-be4e-f99b6de29e23",
+        "resource": {
+          "resourceType": "Patient",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "extension": [
+                {
+                  "url": "code",
+                  "valueCodeableConcept": {
+                    "text": "Patient Nationality",
+                    "coding": [
+                      {
+                        "system": "urn:iso:std:iso:3166",
+                        "code": "SG"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "id": "PPN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "PPN",
+                    "display": "Passport Number"
+                  }
+                ]
+              },
+              "value": "E7831177G"
+            },
+            {
+              "id": "NRIC",
+              "value": "S9098989Z"
+            }
+          ],
+          "name": [
+            {
+              "text": "Tan Chen Chen"
+            }
+          ],
+          "gender": "female",
+          "birthDate": "1990-01-15"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:0275bfaf-48fb-44e0-80cd-9c504f80e6ae",
+        "resource": {
+          "resourceType": "Specimen",
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "258500001",
+                "display": "Nasopharyngeal swab"
+              }
+            ]
+          },
+          "collection": {
+            "collectedDateTime": "2020-09-27T06:15:00Z"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:7729970e-ab26-469f-b3e5-36a42ec24146",
+        "resource": {
+          "resourceType": "Observation",
+          "performer": [
+            {
+              "type": "Practitioner",
+              "reference": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b"
+            }
+          ],
+          "identifier": [
+            {
+              "id": "ACSN",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "ACSN",
+                    "display": "Accession ID"
+                  }
+                ]
+              },
+              "value": "123456789"
+            }
+          ],
+          "category": [
+            {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "840539006",
+                  "display": "COVID-19"
+                }
+              ]
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "94531-1",
+                "display": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
+              }
+            ]
+          },
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative"
+              }
+            ]
+          },
+          "effectiveDateTime": "2020-09-28T06:15:00Z",
+          "status": "final"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:3dbff0de-d4a4-4e1d-98bf-af7428b8a04b",
+        "resource": {
+          "resourceType": "Practitioner",
+          "name": [{ "text": "Dr Michael Lim" }],
+          "qualification": [
+            {
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "MCR",
+                    "display": "Practitioner Medicare number"
+                  }
+                ]
+              },
+              "identifier": [
+                {
+                  "id": "MCR",
+                  "value": "123456"
+                }
+              ],
+              "issuer": {
+                "type": "Organization",
+                "reference": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:bc7065ee-42aa-473a-a614-afd8a7b30b1e",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "Ministry of Health (MOH)",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "govt",
+                  "display": "Government"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.moh.gov.sg" },
+                { "system": "phone", "value": "+6563259220" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "Ministry of Health, 16 College Road, College of Medicine Building, Singapore 169854"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:fa2328af-4882-4eaa-8c28-66dab46950f1",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Medical Clinic",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Licensed Healthcare Provider"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                { "system": "url", "value": "https://www.macritchieclinic.com.sg" },
+                { "system": "phone", "value": "+6561234567" }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "MacRitchie Hospital, Thomson Road, Singapore 123000"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:839a7c54-6b40-41cb-b10d-9295d7e75f77",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Laboratory",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ],
+              "text": "Accredited Laboratory"
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [{ "system": "phone", "value": "+6567654321" }],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "2 Thomson Avenue 4, Singapore 098888"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/sg/gov/moh/pdt-healthcert/2.0/schema.json
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemata.openattestation.com/sg/gov/moh/pdt-healthcert/2.0#",
+  "type": "object",
+  "required": ["id", "version", "type", "validFrom", "fhirVersion", "fhirBundle"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "examples": ["TEST001"]
+    },
+    "version": {
+      "type": "string",
+      "enum": ["PDT-HealthCert-v2.0"]
+    },
+    "type": {
+      "type": "string",
+      "enum": ["PCR", "ART"]
+    },
+    "logo": {
+      "type": "string",
+      "description": "base64 encoded image"
+    },
+    "validFrom": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time from which the document is considered valid"
+    },
+    "fhirVersion": {
+      "type": "string",
+      "examples": ["4.0.1"]
+    },
+    "fhirBundle": {
+      "$ref": "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/lite-schema.json#/definitions/Bundle",
+      "description": "FHIR bundle for a collection of resources. Each resource and the entire bundle should be compliant against the base spec of FHIR. You may use a validator like: https://inferno.healthit.gov/validator/"
+    }
+  }
+}


### PR DESCRIPTION
# PDT HealthCert Schema v2.0

## Rationale

1. Address the differences between HealthCerts and FHIR (As documented in #10 under the _Differences between HealthCerts and FHIR_ paragraph)
2. Ensure FHIR Bundle and its resources are compliant against the base spec

## Breaking Changes

- `fhirBundle` and its nested objects are now rather different than what was defined in v1.0
- Add `version` (enum): `PDT-HealthCert-v2.0`
- Add `type` (enum): `PCR`, `ART`
- Remove `name`

## Overview

The following describes how to properly compose and validate a PDT HealthCert v2.0 in just 2 steps.

### 1. Compose and validate fhirBundle

The `fhirBundle` is a collection of FHIR resources. Each resource and the entire bundle should be compliant against the base spec of FHIR.

**Note**: Since the entire bundle consists of multiple resources, it is recommended to validate each resource first, before validating the entire bundle.

The PDT HealthCert v2.0 requires the following resources to be present:

1. Patient
2. Specimen (*`device` should reference Device resource uuid)
3. Observation (`performer` should reference Practitioner resource uuid)
4. Practitioner (`issuer` should reference to Observation (MOH) resource uuid)
5. Organisation (MOH)
6. Organisation (Licensed Healthcare Provider)
7. Organisation (Accredited Laboratory)
8. *Device

*Device resource is only needed for ART HealthCerts

**How to Compose fhirBundle**

The `fhirBundle` can be easily composed using the following template and modifying the respective fields:

```javascript
// TODO: Insert template or link to an example
```

**Note**: If a provider intends to add additional properties or resources, they would have ensure the added fields remain complaint against the base spec of FHIR.

**How to Validate fhirBundle**

Since a JSON Schema is not able to validate Coding/CodeableConcept bindings (see [documentation on FHIR validation](https://www.hl7.org/fhir/validation.html) for more info), it is recommended to use one of the following validators:

- GUI (Select R4): [https://simplifier.net/validate](https://simplifier.net/validate)
- GUI: [https://inferno.healthit.gov/validator/](https://inferno.healthit.gov/validator/)
- FHIR.js: [https://www.npmjs.com/package/fhir](https://www.npmjs.com/package/fhir)
- Others: [https://confluence.hl7.org/display/FHIR/Open+Source+Implementations](https://confluence.hl7.org/display/FHIR/Open+Source+Implementations)

### 2. Compose and validate HealthCert

Since the bundle and its individual resources have been validated to be FHIR compliant, the next few steps are relatively straightforward. The PDT HealthCert v2.0 consists the following properties:

1. id
2. type
3. name
4. (Optional) logo
5. validFrom
6. fhirVersion
7. *fhirBundle

*The fhirBundle shouldn't be throwing any errors here since we have already validated it to be FHIR compliant in the earlier step.

You may any JSON Schema validators that are available. Here are a few examples:

- GUI: [https://www.jsonschemavalidator.net/](https://www.jsonschemavalidator.net/)
- Ajv.js: [https://ajv.js.org/](https://ajv.js.org/)

## Mappings

```javascript
// TODO: Create a table to document mappings
```