### PR TITLE
fix: improve naming to signedEuHealthCert

### DIFF
--- a/src/sg/gov/tech/notarise/1.0/schema.json
+++ b/src/sg/gov/tech/notarise/1.0/schema.json
@@ -26,13 +26,13 @@
           "type": "string",
           "format": "uri"
         },
-        "encryptedEuHealthCert": {
-          "description": "Encrypted signed offline data document of EU health certificate format (Optional)",
+        "signedEuHealthCert": {
+          "description": "Signed EU Digital COVID Certificate (Optional)",
           "type": "string",
           "examples": ["HC1:1AAA2BBBB"]
         }
       },
-      "required": ["notarisedOn", "passportNumber", "reference", "url"]
+      "required": ["reference", "notarisedOn", "passportNumber", "url"]
     }
   },
   "required": ["notarisationMetadata"]


### PR DESCRIPTION
Improve naming from ~~`encryptedEuHealthCert`~~ to `signedEuHealthCert`
Description: "Signed EU Digital COVID Certificate (Optional)"