### PR TITLE
fix: allow a collection of signedEuHealthCerts

### DIFF
--- a/src/sg/gov/tech/notarise/1.0/sample-document.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document.json
@@ -7,13 +7,13 @@
     "signedEuHealthCerts": [
       {
         "type": "vaccination",
-        "manufacturer": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection",
+        "vaccineCode": "3339641000133109",
         "dose": 1,
         "qr": "HC1:ABCDE..."
       },
       {
         "type": "vaccination",
-        "manufacturer": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection",
+        "vaccineCode": "3339641000133109",
         "dose": 2,
         "qr": "HC1:FGHIJ..."
       }

--- a/src/sg/gov/tech/notarise/1.0/sample-document.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document.json
@@ -3,6 +3,20 @@
     "reference": "967857",
     "notarisedOn": "2020-09-27T06:15:00Z",
     "passportNumber": "DT173NV",
-    "url": "https://example.com"
+    "url": "https://example.com",
+    "signedEuHealthCerts": [
+      {
+        "type": "vaccination",
+        "manufacturer": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection",
+        "dose": 1,
+        "qr": "HC1:ABCDE..."
+      },
+      {
+        "type": "vaccination",
+        "manufacturer": "PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection",
+        "dose": 2,
+        "qr": "HC1:FGHIJ..."
+      }
+    ]
   }
 }

--- a/src/sg/gov/tech/notarise/1.0/sample-document.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document.json
@@ -6,13 +6,13 @@
     "url": "https://example.com",
     "signedEuHealthCerts": [
       {
-        "type": "vaccination",
+        "type": "VAC",
         "vaccineCode": "3339641000133109",
         "dose": 1,
         "qr": "HC1:ABCDE..."
       },
       {
-        "type": "vaccination",
+        "type": "VAC",
         "vaccineCode": "3339641000133109",
         "dose": 2,
         "qr": "HC1:FGHIJ..."

--- a/src/sg/gov/tech/notarise/1.0/schema.json
+++ b/src/sg/gov/tech/notarise/1.0/schema.json
@@ -33,21 +33,36 @@
           "items": {
             "anyOf": [
               {
-                "description": "Vaccination HealthCert",
+                "description": "Vaccination",
                 "type": "object",
-                "required": ["type", "manufacturer", "dose", "qr"],
+                "required": ["type", "vaccineCode", "dose", "qr"],
                 "properties": {
                   "type": {
                     "const": "vaccination"
                   },
-                  "manufacturer": {
+                  "vaccineCode": {
                     "type": "string",
-                    "examples": ["PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection"]
+                    "examples": ["3339641000133109", "3407851000133103"]
                   },
                   "dose": {
                     "description": "Dose number",
                     "type": "number",
                     "examples": [1, 2]
+                  },
+                  "qr": {
+                    "description": "Signed EU Digital COVID Certificate",
+                    "type": "string",
+                    "examples": ["HC1:ABCDE"]
+                  }
+                }
+              },
+              {
+                "description": "Test",
+                "type": "object",
+                "required": ["type", "qr"],
+                "properties": {
+                  "type": {
+                    "const": "test"
                   },
                   "qr": {
                     "description": "Signed EU Digital COVID Certificate",

--- a/src/sg/gov/tech/notarise/1.0/schema.json
+++ b/src/sg/gov/tech/notarise/1.0/schema.json
@@ -26,10 +26,38 @@
           "type": "string",
           "format": "uri"
         },
-        "signedEuHealthCert": {
-          "description": "Signed EU Digital COVID Certificate (Optional)",
-          "type": "string",
-          "examples": ["HC1:1AAA2BBBB"]
+        "signedEuHealthCerts": {
+          "description": "A collection of signed EU Digital COVID Certificates",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "anyOf": [
+              {
+                "description": "Vaccination HealthCert",
+                "type": "object",
+                "required": ["type", "manufacturer", "dose", "qr"],
+                "properties": {
+                  "type": {
+                    "const": "vaccination"
+                  },
+                  "manufacturer": {
+                    "type": "string",
+                    "examples": ["PFIZER-BIONTECH/COMIRNATY COVID-19 Vaccine [Tozinameran] Injection"]
+                  },
+                  "dose": {
+                    "description": "Dose number",
+                    "type": "number",
+                    "examples": [1, 2]
+                  },
+                  "qr": {
+                    "description": "Signed EU Digital COVID Certificate",
+                    "type": "string",
+                    "examples": ["HC1:ABCDE"]
+                  }
+                }
+              }
+            ]
+          }
         }
       },
       "required": ["reference", "notarisedOn", "passportNumber", "url"]

--- a/src/sg/gov/tech/notarise/1.0/schema.json
+++ b/src/sg/gov/tech/notarise/1.0/schema.json
@@ -38,7 +38,7 @@
                 "required": ["type", "vaccineCode", "dose", "qr"],
                 "properties": {
                   "type": {
-                    "const": "vaccination"
+                    "const": "VAC"
                   },
                   "vaccineCode": {
                     "type": "string",
@@ -62,7 +62,7 @@
                 "required": ["type", "qr"],
                 "properties": {
                   "type": {
-                    "const": "test"
+                    "enum": ["PCR", "ART", "SER"]
                   },
                   "qr": {
                     "description": "Signed EU Digital COVID Certificate",

--- a/src/sg/gov/tech/notarise/1.0/schema.test.ts
+++ b/src/sg/gov/tech/notarise/1.0/schema.test.ts
@@ -129,4 +129,127 @@ describe("schema", () => {
       ]
     `);
   });
+  it("should fail when notarisationMetadata signedEuHealthCerts is not an array", () => {
+    const isValid = validator(set(cloneDeep(sampleDocJson), "notarisationMetadata.signedEuHealthCerts", "FOO"));
+    expect(isValid).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts",
+          "keyword": "type",
+          "message": "should be array",
+          "params": Object {
+            "type": "array",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/type",
+        },
+      ]
+    `);
+  });
+  it("should fail when notarisationMetadata signedEuHealthCerts[0] is missing required fields", () => {
+    const isValid = validator(
+      omit(cloneDeep(sampleDocJson), [
+        "notarisationMetadata.signedEuHealthCerts[0].type",
+        "notarisationMetadata.signedEuHealthCerts[0].manufacturer",
+        "notarisationMetadata.signedEuHealthCerts[0].dose",
+        "notarisationMetadata.signedEuHealthCerts[0].qr"
+      ])
+    );
+    expect(isValid).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'type'",
+          "params": Object {
+            "missingProperty": "type",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'manufacturer'",
+          "params": Object {
+            "missingProperty": "manufacturer",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'dose'",
+          "params": Object {
+            "missingProperty": "dose",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'qr'",
+          "params": Object {
+            "missingProperty": "qr",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "anyOf",
+          "message": "should match some schema in anyOf",
+          "params": Object {},
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf",
+        },
+      ]
+    `);
+  });
+  it("should fail when notarisationMetadata signedEuHealthCerts[0] is not a valid type", () => {
+    const isValid = validator(set(cloneDeep(sampleDocJson), "notarisationMetadata.signedEuHealthCerts[0].type", "FOO"));
+    expect(isValid).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].type",
+          "keyword": "const",
+          "message": "should be equal to constant",
+          "params": Object {
+            "allowedValue": "vaccination",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/properties/type/const",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "anyOf",
+          "message": "should match some schema in anyOf",
+          "params": Object {},
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf",
+        },
+      ]
+    `);
+  });
+  it("should fail when notarisationMetadata signedEuHealthCerts[0] is not a valid dose", () => {
+    const isValid = validator(set(cloneDeep(sampleDocJson), "notarisationMetadata.signedEuHealthCerts[0].dose", "FOO"));
+    expect(isValid).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].dose",
+          "keyword": "type",
+          "message": "should be number",
+          "params": Object {
+            "type": "number",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/properties/dose/type",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "anyOf",
+          "message": "should match some schema in anyOf",
+          "params": Object {},
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf",
+        },
+      ]
+    `);
+  });
 });

--- a/src/sg/gov/tech/notarise/1.0/schema.test.ts
+++ b/src/sg/gov/tech/notarise/1.0/schema.test.ts
@@ -232,18 +232,22 @@ describe("schema", () => {
           "keyword": "const",
           "message": "should be equal to constant",
           "params": Object {
-            "allowedValue": "vaccination",
+            "allowedValue": "VAC",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/properties/type/const",
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].type",
-          "keyword": "const",
-          "message": "should be equal to constant",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
           "params": Object {
-            "allowedValue": "test",
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
           },
-          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/const",
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/enum",
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
@@ -271,12 +275,16 @@ describe("schema", () => {
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].type",
-          "keyword": "const",
-          "message": "should be equal to constant",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
           "params": Object {
-            "allowedValue": "test",
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
           },
-          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/const",
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/enum",
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",

--- a/src/sg/gov/tech/notarise/1.0/schema.test.ts
+++ b/src/sg/gov/tech/notarise/1.0/schema.test.ts
@@ -150,7 +150,7 @@ describe("schema", () => {
     const isValid = validator(
       omit(cloneDeep(sampleDocJson), [
         "notarisationMetadata.signedEuHealthCerts[0].type",
-        "notarisationMetadata.signedEuHealthCerts[0].manufacturer",
+        "notarisationMetadata.signedEuHealthCerts[0].vaccineCode",
         "notarisationMetadata.signedEuHealthCerts[0].dose",
         "notarisationMetadata.signedEuHealthCerts[0].qr"
       ])
@@ -170,9 +170,9 @@ describe("schema", () => {
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
           "keyword": "required",
-          "message": "should have required property 'manufacturer'",
+          "message": "should have required property 'vaccineCode'",
           "params": Object {
-            "missingProperty": "manufacturer",
+            "missingProperty": "vaccineCode",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
         },
@@ -193,6 +193,24 @@ describe("schema", () => {
             "missingProperty": "qr",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'type'",
+          "params": Object {
+            "missingProperty": "type",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'qr'",
+          "params": Object {
+            "missingProperty": "qr",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/required",
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
@@ -219,6 +237,15 @@ describe("schema", () => {
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/properties/type/const",
         },
         Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].type",
+          "keyword": "const",
+          "message": "should be equal to constant",
+          "params": Object {
+            "allowedValue": "test",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/const",
+        },
+        Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
           "keyword": "anyOf",
           "message": "should match some schema in anyOf",
@@ -241,6 +268,15 @@ describe("schema", () => {
             "type": "number",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/properties/dose/type",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].type",
+          "keyword": "const",
+          "message": "should be equal to constant",
+          "params": Object {
+            "allowedValue": "test",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/const",
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",


### PR DESCRIPTION
`type` utilises a similar naming convention as this: https://github.com/Open-Attestation/schemata/blob/master/src/sg/gov/moh/pdt-healthcert/2.0/schema.json#L15-L18

## Vaccination HealthCert
```json
{
  ...
  "signedEuHealthCerts": [
    {
      "type": "VAC",
      "vaccineCode": "3339641000133109",
      "dose": 1,
      "qr": "HC1:ABCDE..."
    },
    {
      "type": "VAC",
      "vaccineCode": "3339641000133109",
      "dose": 2,
      "qr": "HC1:FGHIJ..."
    }
    ...
  ]
}
```

## PDT HealthCert
```json
{
  ...
  "signedEuHealthCerts": [
    {
      "type": "PCR",
      "qr": "HC1:ABCDE..."
    },
    ...
  ]
}
```