### PR TITLE
fix: allow multiple types for PDT Schema v2.0

### DIFF
--- a/src/sg/gov/moh/pdt-healthcert/2.0/schema.json
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/schema.json
@@ -3,6 +3,12 @@
   "$id": "https://schemata.openattestation.com/sg/gov/moh/pdt-healthcert/2.0#",
   "type": "object",
   "required": ["id", "version", "type", "validFrom", "fhirVersion", "fhirBundle"],
+  "definitions": {
+    "PdtTypes": {
+      "type": "string",
+      "enum": ["PCR", "ART", "SER"]
+    }
+  },
   "properties": {
     "id": {
       "type": "string",
@@ -13,8 +19,15 @@
       "enum": ["pdt-healthcert-v2.0"]
     },
     "type": {
-      "type": "string",
-      "enum": ["PCR", "ART", "SER"]
+      "oneOf": [
+        { "$ref": "#/definitions/PdtTypes" },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/PdtTypes" },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      ]
     },
     "logo": {
       "type": "string",

--- a/src/sg/gov/moh/pdt-healthcert/2.0/schema.test.ts
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/schema.test.ts
@@ -77,6 +77,162 @@ describe("schema", () => {
     `);
   });
 
+  it("should fail when type is not part of enum", () => {
+    const document = set(cloneDeep(sampleDocument), "type", "foo");
+    expect(validator(document)).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".type",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
+          "params": Object {
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
+          },
+          "schemaPath": "#/definitions/PdtTypes/enum",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "type",
+          "message": "should be array",
+          "params": Object {
+            "type": "array",
+          },
+          "schemaPath": "#/properties/type/oneOf/1/type",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "oneOf",
+          "message": "should match exactly one schema in oneOf",
+          "params": Object {
+            "passingSchemas": null,
+          },
+          "schemaPath": "#/properties/type/oneOf",
+        },
+      ]
+    `);
+  });
+
+  it("should fail when type is not a valid array of enum", () => {
+    const document = set(cloneDeep(sampleDocument), "type", ["foo", "bar"]);
+    expect(validator(document)).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".type",
+          "keyword": "type",
+          "message": "should be string",
+          "params": Object {
+            "type": "string",
+          },
+          "schemaPath": "#/definitions/PdtTypes/type",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
+          "params": Object {
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
+          },
+          "schemaPath": "#/definitions/PdtTypes/enum",
+        },
+        Object {
+          "dataPath": ".type[0]",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
+          "params": Object {
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
+          },
+          "schemaPath": "#/definitions/PdtTypes/enum",
+        },
+        Object {
+          "dataPath": ".type[1]",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
+          "params": Object {
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
+          },
+          "schemaPath": "#/definitions/PdtTypes/enum",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "oneOf",
+          "message": "should match exactly one schema in oneOf",
+          "params": Object {
+            "passingSchemas": null,
+          },
+          "schemaPath": "#/properties/type/oneOf",
+        },
+      ]
+    `);
+  });
+
+  it("should fail when type is non-unique array of enum", () => {
+    const document = set(cloneDeep(sampleDocument), "type", ["PCR", "PCR"]);
+    expect(validator(document)).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".type",
+          "keyword": "type",
+          "message": "should be string",
+          "params": Object {
+            "type": "string",
+          },
+          "schemaPath": "#/definitions/PdtTypes/type",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
+          "params": Object {
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
+          },
+          "schemaPath": "#/definitions/PdtTypes/enum",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "uniqueItems",
+          "message": "should NOT have duplicate items (items ## 0 and 1 are identical)",
+          "params": Object {
+            "i": 1,
+            "j": 0,
+          },
+          "schemaPath": "#/properties/type/oneOf/1/uniqueItems",
+        },
+        Object {
+          "dataPath": ".type",
+          "keyword": "oneOf",
+          "message": "should match exactly one schema in oneOf",
+          "params": Object {
+            "passingSchemas": null,
+          },
+          "schemaPath": "#/properties/type/oneOf",
+        },
+      ]
+    `);
+  });
+
   it("should fail when validFrom is missing", () => {
     const document = omit(cloneDeep(sampleDocument), "validFrom");
     expect(validator(document)).toBe(false);


### PR DESCRIPTION
Modify the `type` field so it can hold multiple types:

```javascript
type = "PCR"           // Valid
type = ["PCR", "SER"]  // Valid

type = ["PCR", "PCR"]  // Invalid
type = ""              // Invalid
type = []              // Invalid
```