### PR TITLE
fix: resolving schema reference

### DIFF
--- a/scripts/lite-fhir-schema.js
+++ b/scripts/lite-fhir-schema.js
@@ -13,8 +13,8 @@ const schemaHeader = {
   $id: "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/lite-schema.json#",
   // id: "http://hl7.org/fhir/json-schema/4.0",
   title: "Lite FHIR schema for Notarise.gov.sg HealthCerts",
-  description: "see http://hl7.org/fhir/json.html#schema for information about the FHIR Json Schemas",
-  $ref: "#/definitions/Bundle"
+  description: "see http://hl7.org/fhir/json.html#schema for information about the FHIR Json Schemas"
+  // $ref: "#/definitions/Bundle"
 };
 
 /** ====== Helper Functions ====== **/

--- a/src/sg/gov/moh/fhir/4.0.1/lite-schema.json
+++ b/src/sg/gov/moh/fhir/4.0.1/lite-schema.json
@@ -3,7 +3,6 @@
   "$id": "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/lite-schema.json#",
   "title": "Lite FHIR schema for Notarise.gov.sg HealthCerts",
   "description": "see http://hl7.org/fhir/json.html#schema for information about the FHIR Json Schemas",
-  "$ref": "#/definitions/Bundle",
   "definitions": {
     "ResourceList": {
       "oneOf": [

--- a/src/sg/gov/moh/pdt-healthcert/2.0/schema.json
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/schema.json
@@ -43,7 +43,7 @@
       "examples": ["4.0.1"]
     },
     "fhirBundle": {
-      "$ref": "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/lite-schema.json",
+      "$ref": "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/lite-schema.json#/definitions/Bundle",
       "description": "FHIR bundle for a collection of resources. Each resource and the entire bundle should be compliant against the base spec of FHIR. You may use a validator like: https://inferno.healthit.gov/validator/"
     }
   }


### PR DESCRIPTION
# Problem

When using the online [JSON Schema Validator](https://www.jsonschemavalidator.net/) tool, the following error message appears:

![www jsonschemavalidator net_](https://user-images.githubusercontent.com/37650399/135031326-eeb9a3e4-67fb-4e17-8b15-9ec659fe9e7f.png)

# Resolution

This PR attempts to resolve this error by removing the `$ref` in `src/sg/gov/moh/fhir/4.0.1/lite-schema.json` and explicitly reference the Bundle definition in `src/sg/gov/moh/pdt-healthcert/2.0/schema.json`.

![www jsonschemavalidator net_](https://user-images.githubusercontent.com/37650399/135031692-42a6df67-71cd-49d5-9cfb-673d5a5d2d6c.png)