### PR TITLE
fix: add expiryDateTime field to signedEuHealthCerts

### DIFF
--- a/src/sg/gov/tech/notarise/1.0/sample-document-pdt.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document-pdt.json
@@ -7,6 +7,7 @@
     "signedEuHealthCerts": [
       {
         "type": "PCR",
+        "expiryDateTime": "2022-12-09T20:20:50+08:00",
         "qr": "HC1:ABCDE..."
       }
     ]

--- a/src/sg/gov/tech/notarise/1.0/sample-document-vac.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document-vac.json
@@ -7,12 +7,14 @@
     "signedEuHealthCerts": [
       {
         "type": "VAC",
+        "expiryDateTime": "2022-12-09T20:20:50+08:00",
         "vaccineCode": "3339641000133109",
         "dose": 1,
         "qr": "HC1:ABCDE..."
       },
       {
         "type": "VAC",
+        "expiryDateTime": "2022-12-09T20:20:50+08:00",
         "vaccineCode": "3339641000133109",
         "dose": 2,
         "qr": "HC1:FGHIJ..."

--- a/src/sg/gov/tech/notarise/1.0/schema.json
+++ b/src/sg/gov/tech/notarise/1.0/schema.json
@@ -35,10 +35,14 @@
               {
                 "description": "Vaccination",
                 "type": "object",
-                "required": ["type", "vaccineCode", "dose", "qr"],
+                "required": ["type", "expiryDateTime", "vaccineCode", "dose", "qr"],
                 "properties": {
                   "type": {
                     "const": "VAC"
+                  },
+                  "expiryDateTime": {
+                    "format": "date-time",
+                    "examples": ["2022-12-09T20:20:50+08:00"]
                   },
                   "vaccineCode": {
                     "type": "string",
@@ -59,10 +63,14 @@
               {
                 "description": "Test",
                 "type": "object",
-                "required": ["type", "qr"],
+                "required": ["type", "expiryDateTime", "qr"],
                 "properties": {
                   "type": {
                     "enum": ["PCR", "ART", "SER"]
+                  },
+                  "expiryDateTime": {
+                    "format": "date-time",
+                    "examples": ["2022-12-09T20:20:50+08:00"]
                   },
                   "qr": {
                     "description": "Signed EU Digital COVID Certificate",

--- a/src/sg/gov/tech/notarise/1.0/schema.test.ts
+++ b/src/sg/gov/tech/notarise/1.0/schema.test.ts
@@ -155,6 +155,7 @@ describe("schema", () => {
     const isValid = validator(
       omit(cloneDeep(sampleVac), [
         "notarisationMetadata.signedEuHealthCerts[0].type",
+        "notarisationMetadata.signedEuHealthCerts[0].expiryDateTime",
         "notarisationMetadata.signedEuHealthCerts[0].vaccineCode",
         "notarisationMetadata.signedEuHealthCerts[0].dose",
         "notarisationMetadata.signedEuHealthCerts[0].qr"
@@ -169,6 +170,15 @@ describe("schema", () => {
           "message": "should have required property 'type'",
           "params": Object {
             "missingProperty": "type",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'expiryDateTime'",
+          "params": Object {
+            "missingProperty": "expiryDateTime",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
         },
@@ -205,6 +215,15 @@ describe("schema", () => {
           "message": "should have required property 'type'",
           "params": Object {
             "missingProperty": "type",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'expiryDateTime'",
+          "params": Object {
+            "missingProperty": "expiryDateTime",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/required",
         },
@@ -253,6 +272,54 @@ describe("schema", () => {
             ],
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/enum",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "anyOf",
+          "message": "should match some schema in anyOf",
+          "params": Object {},
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf",
+        },
+      ]
+    `);
+  });
+  it("should fail when notarisationMetadata signedEuHealthCerts[0] is not a valid expiryDateTime", () => {
+    const isValid = validator(
+      set(cloneDeep(sampleVac), "notarisationMetadata.signedEuHealthCerts[0].expiryDateTime", "FOO")
+    );
+    expect(isValid).toBe(false);
+    expect(validator.errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].expiryDateTime",
+          "keyword": "format",
+          "message": "should match format \\"date-time\\"",
+          "params": Object {
+            "format": "date-time",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/properties/expiryDateTime/format",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].type",
+          "keyword": "enum",
+          "message": "should be equal to one of the allowed values",
+          "params": Object {
+            "allowedValues": Array [
+              "PCR",
+              "ART",
+              "SER",
+            ],
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/type/enum",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0].expiryDateTime",
+          "keyword": "format",
+          "message": "should match format \\"date-time\\"",
+          "params": Object {
+            "format": "date-time",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/properties/expiryDateTime/format",
         },
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",


### PR DESCRIPTION
**What does this PR do?**
Adds an additional `expiryDateTime` under `signedEuHealthCerts`

Story: https://www.pivotaltracker.com/story/show/180580440