### PR TITLE
chore: added modality to healthcert

### DIFF
--- a/src/sg/gov/moh/fhir/4.0.1/lite-schema.json
+++ b/src/sg/gov/moh/fhir/4.0.1/lite-schema.json
@@ -156,6 +156,14 @@
         "text": {
           "description": "The text of the annotation in markdown format.",
           "$ref": "#/definitions/markdown"
+        },
+        "modality": {
+          "description": "The way in which the ART test is medically supervised",
+          "enum": [
+            "Administered",
+            "Supervised",
+            "Remotely Supervised"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Background
https://www.pivotaltracker.com/story/show/181200750


Given recent developments in ART test types, MOH wants to check if HealthCert ART schema can include a field for "modality" of the test. Values are "Administered","Supervised" and "Remotely Supervised"