### PR TITLE
feat: export PDT HealthCert v2.0 schemas

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import * as geekout from "./__generated__/sg/gov/tech/geekout/1.0/schema";
 import * as notarise from "./__generated__/sg/gov/tech/notarise/1.0/schema";
 import * as pdtHealthCertV2 from "./__generated__/sg/gov/moh/pdt-healthcert/2.0/schema";
 import * as vaccinationHealthcert from "./__generated__/sg/gov/moh/vaccination-healthcert/1.0/schema";
-import * as pdtHealthCertV2Schemas from "./sg/gov/moh/pdt-healthcert/2.0";
 
-export { geekout, notarise, pdtHealthCertV2, pdtHealthCertV2Schemas, vaccinationHealthcert };
+import * as pdtHealthCertV2Schema from "./sg/gov/moh/pdt-healthcert/2.0";
+import * as fhirSchema from "./sg/gov/moh/fhir/4.0.1";
+
+export { geekout, notarise, pdtHealthCertV2, vaccinationHealthcert, pdtHealthCertV2Schema, fhirSchema };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ import * as geekout from "./__generated__/sg/gov/tech/geekout/1.0/schema";
 import * as notarise from "./__generated__/sg/gov/tech/notarise/1.0/schema";
 import * as pdtHealthCertV2 from "./__generated__/sg/gov/moh/pdt-healthcert/2.0/schema";
 import * as vaccinationHealthcert from "./__generated__/sg/gov/moh/vaccination-healthcert/1.0/schema";
+import * as pdtHealthCertV2Schemas from "./sg/gov/moh/pdt-healthcert/2.0";
 
-export { geekout, notarise, pdtHealthCertV2, vaccinationHealthcert };
+export { geekout, notarise, pdtHealthCertV2, pdtHealthCertV2Schemas, vaccinationHealthcert };

--- a/src/sg/gov/moh/fhir/4.0.1/index.ts
+++ b/src/sg/gov/moh/fhir/4.0.1/index.ts
@@ -1,0 +1,3 @@
+import liteFhirSchema from "./lite-schema.json";
+
+export { liteFhirSchema };

--- a/src/sg/gov/moh/pdt-healthcert/2.0/index.ts
+++ b/src/sg/gov/moh/pdt-healthcert/2.0/index.ts
@@ -1,0 +1,5 @@
+import schema from "./schema.json";
+import clinicProviderSchema from "./clinic-provider-schema.json";
+import endorsedSchema from "./endorsed-schema.json";
+
+export { schema, clinicProviderSchema, endorsedSchema };


### PR DESCRIPTION
**What does this PR do?**
Exports PDT HealthCert v2.0 schemas so they can be imported by other services.

**Use case**
PR: Notarise-gov-sg/api-notarise-healthcerts/pull/503 ([context](https://github.com/Notarise-gov-sg/api-notarise-healthcerts/pull/503#discussion_r824422627))

JSON schema validation will be very costly if the schema is fetched over the network upon every validation. As such, it is proposed to export schemas from the `oa-schemata` package so they can be imported locally by other services.