### PR TITLE
fix: add appleCovidCardUrl field to notarisationMetadata

### DIFF
--- a/src/sg/gov/tech/notarise/1.0/sample-document-pdt.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document-pdt.json
@@ -8,7 +8,8 @@
       {
         "type": "PCR",
         "expiryDateTime": "2022-12-09T20:20:50+08:00",
-        "qr": "HC1:ABCDE..."
+        "qr": "HC1:ABCDE...",
+        "appleCovidCardUrl": "https://redirect.health.apple.com/EU-DCC/#..."
       }
     ]
   }

--- a/src/sg/gov/tech/notarise/1.0/sample-document-vac.json
+++ b/src/sg/gov/tech/notarise/1.0/sample-document-vac.json
@@ -10,14 +10,16 @@
         "expiryDateTime": "2022-12-09T20:20:50+08:00",
         "vaccineCode": "3339641000133109",
         "dose": 1,
-        "qr": "HC1:ABCDE..."
+        "qr": "HC1:ABCDE...",
+        "appleCovidCardUrl": "https://redirect.health.apple.com/EU-DCC/#..."
       },
       {
         "type": "VAC",
         "expiryDateTime": "2022-12-09T20:20:50+08:00",
         "vaccineCode": "3339641000133109",
         "dose": 2,
-        "qr": "HC1:FGHIJ..."
+        "qr": "HC1:FGHIJ...",
+        "appleCovidCardUrl": "https://redirect.health.apple.com/EU-DCC/#..."
       }
     ]
   }

--- a/src/sg/gov/tech/notarise/1.0/schema.json
+++ b/src/sg/gov/tech/notarise/1.0/schema.json
@@ -35,7 +35,7 @@
               {
                 "description": "Vaccination",
                 "type": "object",
-                "required": ["type", "expiryDateTime", "vaccineCode", "dose", "qr"],
+                "required": ["type", "expiryDateTime", "vaccineCode", "dose", "qr", "appleCovidCardUrl"],
                 "properties": {
                   "type": {
                     "const": "VAC"
@@ -57,13 +57,18 @@
                     "description": "Signed EU Digital COVID Certificate",
                     "type": "string",
                     "examples": ["HC1:ABCDE"]
+                  },
+                  "appleCovidCardUrl": {
+                    "description": "URL to add to Apple Wallet and Health",
+                    "type": "string",
+                    "examples": ["https://redirect.health.apple.com/EU-DCC/#..."]
                   }
                 }
               },
               {
                 "description": "Test",
                 "type": "object",
-                "required": ["type", "expiryDateTime", "qr"],
+                "required": ["type", "expiryDateTime", "qr", "appleCovidCardUrl"],
                 "properties": {
                   "type": {
                     "enum": ["PCR", "ART", "SER"]
@@ -76,6 +81,11 @@
                     "description": "Signed EU Digital COVID Certificate",
                     "type": "string",
                     "examples": ["HC1:ABCDE"]
+                  },
+                  "appleCovidCardUrl": {
+                    "description": "URL to add to Apple Wallet and Health",
+                    "type": "string",
+                    "examples": ["https://redirect.health.apple.com/EU-DCC/#..."]
                   }
                 }
               }

--- a/src/sg/gov/tech/notarise/1.0/schema.test.ts
+++ b/src/sg/gov/tech/notarise/1.0/schema.test.ts
@@ -158,7 +158,8 @@ describe("schema", () => {
         "notarisationMetadata.signedEuHealthCerts[0].expiryDateTime",
         "notarisationMetadata.signedEuHealthCerts[0].vaccineCode",
         "notarisationMetadata.signedEuHealthCerts[0].dose",
-        "notarisationMetadata.signedEuHealthCerts[0].qr"
+        "notarisationMetadata.signedEuHealthCerts[0].qr",
+        "notarisationMetadata.signedEuHealthCerts[0].appleCovidCardUrl"
       ])
     );
     expect(isValid).toBe(false);
@@ -212,6 +213,15 @@ describe("schema", () => {
         Object {
           "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
           "keyword": "required",
+          "message": "should have required property 'appleCovidCardUrl'",
+          "params": Object {
+            "missingProperty": "appleCovidCardUrl",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/0/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
           "message": "should have required property 'type'",
           "params": Object {
             "missingProperty": "type",
@@ -233,6 +243,15 @@ describe("schema", () => {
           "message": "should have required property 'qr'",
           "params": Object {
             "missingProperty": "qr",
+          },
+          "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/required",
+        },
+        Object {
+          "dataPath": ".notarisationMetadata.signedEuHealthCerts[0]",
+          "keyword": "required",
+          "message": "should have required property 'appleCovidCardUrl'",
+          "params": Object {
+            "missingProperty": "appleCovidCardUrl",
           },
           "schemaPath": "#/properties/notarisationMetadata/properties/signedEuHealthCerts/items/anyOf/1/required",
         },


### PR DESCRIPTION
**What does this PR do?**
- Add `appleCovidCardUrl` as required field under `notarisationMetadata.signedEuHealthCerts`
- Update tests