### PR TITLE
fix: cover letter storage

### DIFF
--- a/src/io/tradetrust/cover-letter/1.0/cover-letter-context.json
+++ b/src/io/tradetrust/cover-letter/1.0/cover-letter-context.json
@@ -11,7 +11,18 @@
       "remarks": "xsd:string",
       "backgroundColor": "xsd:string",
       "titleColor": "xsd:string",
-      "remarksColor": "xsd:string"
+      "remarksColor": "xsd:string",
+      "links": {
+        "@id": "https://schemata.openattestation.com/vocab/#links",
+        "@context": {
+          "self": {
+            "@id": "https://schemata.openattestation.com/vocab/#self",
+            "@context": {
+              "href": "xsd:string"
+            }
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
- missed out `links` schema, used for document storage