### PR TITLE
chore: finalise oa v4 context url

### DIFF
--- a/scripts/publish-schema.sh
+++ b/scripts/publish-schema.sh
@@ -35,3 +35,6 @@ mkdir -p ./public/com/openattestation/1.0
 cp ./public/com/openattestation/3.0/CustomContext.json ./public/com/openattestation/1.0/CustomContext.json 
 cp ./public/com/openattestation/3.0/DrivingLicenceCredential.json ./public/com/openattestation/1.0/DrivingLicenceCredential.json 
 cp ./public/com/openattestation/3.0/OpenAttestation.v3.json ./public/com/openattestation/1.0/OpenAttestation.v3.json
+
+# [Temporarily maintain backwards compatibility] Ensure 4.0 alpha context file is still available
+cp ./public/com/openattestation/4.0/context.json ./public/com/openattestation/4.0/alpha-context.json

--- a/src/com/openattestation/4.0/context.json
+++ b/src/com/openattestation/4.0/context.json
@@ -3,7 +3,7 @@
     "@version": 1.1,
     "@protected": true,
     "schema": "https://schema.org/",
-    "oacred": "https://schemata.openattestation.com/com/openattestation/4.0/alpha-context.json#",
+    "oacred": "https://schemata.openattestation.com/com/openattestation/4.0/context.json#",
     "OpenAttestationCredential": {
       "@id": "oacred:OpenAttestationCredential",
       "@context": { "name": "schema:name" }


### PR DESCRIPTION
## What does this PR do?
- Remove `alpha-` prefix for OA v4 Context URL
- Temporarily maintain hosting of old url for backwards compatibility